### PR TITLE
Change unwrap to be unsafe

### DIFF
--- a/option.go
+++ b/option.go
@@ -50,14 +50,10 @@ func (o Option[T]) Expect(msg string) (T, error) {
 	return o.data, nil
 }
 
-// Unwrap returns the contained `Some` value.
-// Returns an error if the option is `None`
-func (o Option[T]) Unwrap() (T, error) {
-	if o.IsNone() {
-		var t T
-		return t, errors.New("unwrap called on empty Option")
-	}
-	return o.data, nil
+// Unwrap returns the contained `Some` value unsafely.
+// Behavior is not defined if called on a `None`
+func (o Option[T]) Unwrap() T {
+	return o.data
 }
 
 // UnwrapOr returns the contained `Some` value or

--- a/option_test.go
+++ b/option_test.go
@@ -121,29 +121,19 @@ func TestExpect(t *testing.T) {
 }
 func TestUnwrap(t *testing.T) {
 	tests := map[string]struct {
-		value         option.Option[int]
-		inner         int
-		expectedError bool
+		value option.Option[int]
+		inner int
 	}{
 		"some_value": {
-			value:         option.Some(1),
-			inner:         1,
-			expectedError: false,
-		},
-		"no_value": {
-			value:         option.None[int](),
-			inner:         0,
-			expectedError: true,
+			value: option.Some(1),
+			inner: 1,
 		},
 	}
 
 	for tname, tc := range tests {
 		t.Run(tname, func(t *testing.T) {
-			val, err := tc.value.Unwrap()
-			if (err != nil) != tc.expectedError {
-				t.Fail()
-			}
-			if !tc.expectedError && val != tc.inner {
+			val := tc.value.Unwrap()
+			if val != tc.inner {
 				t.Fail()
 			}
 		})


### PR DESCRIPTION
As defined by the Rust spec, `Unwrap` should panic in Rust. The better translation of this to Go would be not having defined behavior and just returning something of type `T`. If returning an error is desired, the `Expect` method can be used.